### PR TITLE
[pokedex/models] Use concrete_fields

### DIFF
--- a/pokedex/models.py
+++ b/pokedex/models.py
@@ -32,7 +32,7 @@ class PokedexCreature(models.Model):
     def get_fields(cls):
         return [
             field.name 
-            for field in cls._meta.get_fields()
+            for field in cls._meta.concrete_fields
             if field.name != 'id'
         ]
 
@@ -40,7 +40,7 @@ class PokedexCreature(models.Model):
     def get_mandatory_fields(cls):
         return [
             field.name
-            for field in cls._meta.get_fields()
+            for field in cls._meta.concrete_fields
             if field.name != 'id' and not field.null 
         ]
 


### PR DESCRIPTION
_meta.get_fields() include relational fields from outside
models. Use concrete_fields instead to ensure
we have only field define in the current model